### PR TITLE
fix: Decouple rrweb events from integration instance

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -7,9 +7,10 @@ import * as Sentry from '@sentry/browser';
 import SentryRRWeb from '@sentry/rrweb';
 
 Sentry.init({
-  dsn: 'https://375821616abb4d8c94f43726ed08e27f@ingest.sentry.io/2273529',
+  dsn:
+    'https://375821616abb4d8c94f43726ed08e27f@o19635.ingest.sentry.io/2273529',
   environment: 'demo',
-  integrations: [new SentryRRWeb()]
+  integrations: [new SentryRRWeb()],
 });
 
 ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
Correct an issue where `self` isnt present during the lifecycle of setupOnce, causing rrweb to sometimes record events before the Sentry instance is available.

This also installs rrweb immediately at instantiation time for the integration, ensuring we create a more accurate set of events in replays.

Fixes #11