### PR TITLE
Bump rrweb version to 0.9.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -216,6 +216,12 @@
         "tslib": "^1.9.3"
       }
     },
+    "@types/css-font-loading-module": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.4.tgz",
+      "integrity": "sha512-ENdXf7MW4m9HeDojB2Ukbi7lYMIuQNBHVf98dbzaiG4EEJREBd6oleVAjrLRCrp7dm6CK1mmdmU9tcgF61acbw==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.42",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.42.tgz",
@@ -228,10 +234,10 @@
       "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
       "dev": true
     },
-    "@types/smoothscroll-polyfill": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/smoothscroll-polyfill/-/smoothscroll-polyfill-0.3.1.tgz",
-      "integrity": "sha512-+KkHw4y+EyeCtVXET7woHUhIbfWFCflc0E0mZnSV+ZdjPQeHt/9KPEuT7gSW/kFQ8O3EG30PLO++YhChDt8+Ag==",
+    "@xstate/fsm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.0.tgz",
+      "integrity": "sha512-YJpzKLPxMBUUQCTkjIbicsax6svTbPz5ykTkotIaa3kOoTnBJ4CWfC0cSQuMg7FAsfV2XWOuEsFq0dbmY7NtXg==",
       "dev": true
     },
     "acorn": {
@@ -337,6 +343,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
       "dev": true
     },
     "find-cache-dir": {
@@ -553,12 +565,6 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
-    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -668,22 +674,22 @@
       }
     },
     "rrweb": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-0.7.33.tgz",
-      "integrity": "sha512-TJIkNlejmyBScUbnBRCzeSgRFANx2dX0kGRZLeWKz6ZkSbWs4UhWv0DuRHEPSXH4/BV1b4PVtKBOMsY9wvm0jg==",
+      "version": "0.9.14",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-0.9.14.tgz",
+      "integrity": "sha512-nm2rrVNoyWFPrbGQmcvTTlA7XjbbgPIgO7qsW0Zyr5iOURIFJDGPHFmOVLRyLpWiriVtEoXh6a+x+D1sj+qwWg==",
       "dev": true,
       "requires": {
-        "@types/smoothscroll-polyfill": "^0.3.0",
+        "@types/css-font-loading-module": "0.0.4",
+        "@xstate/fsm": "^1.4.0",
+        "fflate": "^0.4.4",
         "mitt": "^1.1.3",
-        "pako": "^1.0.11",
-        "rrweb-snapshot": "^0.7.26",
-        "smoothscroll-polyfill": "^0.4.3"
+        "rrweb-snapshot": "^1.0.3"
       }
     },
     "rrweb-snapshot": {
-      "version": "0.7.26",
-      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-0.7.26.tgz",
-      "integrity": "sha512-z4k6swLNI5YPDFFcYp19Ggo2kE12cWG1OZCanlaMvwSOi82OOZ229ckYBCPYHbYQnCwuBF5KSMZi2i0CwpWHng==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-1.0.7.tgz",
+      "integrity": "sha512-6fu9+KiQlFPkFk2SdahIDsV+yu1juiAR/o+kOiwKPbXur1TiFGMPAfaQNCkqLc8Nvyx3ItkJmrIldyxnAalEag==",
       "dev": true
     },
     "safe-buffer": {
@@ -696,12 +702,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
-    },
-    "smoothscroll-polyfill": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
-      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   },
   "homepage": "https://github.com/getsentry/sentry-rrweb#readme",
   "peerDependencies": {
-    "rrweb": ">=0.7.0",
+    "rrweb": ">=0.9.0",
     "@sentry/browser": ">=4.0.0"
   },
   "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.7.2",
-    "rrweb": "^0.7.33",
+    "rrweb": "^0.9.14",
     "@sentry/browser": "^5.10.2",
     "@sentry/types": "^5.10.0",
     "rimraf": "^3.0.0",


### PR DESCRIPTION
I've tested rrweb 0.9.14 in a production environment with Sentry. Version 0.9.14 seems to be much more stable (still not all the way there) and throws less console errors. 