### PR TITLE
Move processEvent to a separate method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,10 @@ export default class SentryRRWeb {
     });
   }
 
+  public setupOnce() {
+    Sentry.addGlobalEventProcessor((event: Event) => this.processEvent(event));
+  }
+
   public attachmentUrlFromDsn(dsn: Dsn, eventId: string) {
     const { host, path, projectId, port, protocol, user } = dsn;
     return `${protocol}://${host}${port !== '' ? `:${port}` : ''}${
@@ -81,9 +85,5 @@ export default class SentryRRWeb {
     } catch (ex) {
       console.error(ex);
     }
-  }
-
-  public setupOnce() {
-    Sentry.addGlobalEventProcessor((event: Event) => this.processEvent(event));
   }
 }


### PR DESCRIPTION
Small refactor - I noticed the docs on [Sampling](https://docs.sentry.io/platforms/javascript/configuration/integrations/rrweb/#sampling) suggest globally doing something like `const hasReplays = getCurrentUser().isStaff`. But that isn't always known when Sentry is initialized. This change allows extending the SentryRRWeb class so that you can override the `processEvent` method to check user details and skip sending the attachment based on user type.

Note: if you view the diff with https://github.com/getsentry/sentry-rrweb/pull/56/files?w=1 you can see it's a small change:

<img width="1717" alt="image" src="https://user-images.githubusercontent.com/15040698/158486098-937cd5a4-cb6d-4dcf-9dfb-0b9c1c3f7bd9.png">
