### PR TITLE
fix(deps): Make dsn compatible with JS SDK 7.x

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "declaration": true,
     "declarationDir": "./dist",
     "module": "es6",
+    "moduleResolution": "node",
     "noImplicitAny": true,
     "esModuleInterop": true,
     "outDir": "./dist",


### PR DESCRIPTION
This is a quick fix to unblock use of this plugin with the new 7.0 version of the JS SDK, changing the `Dsn` type to `any` (since it's gone in 7.0) and looking for the public key under both its new and old names. (Our listed peer dependency is the wide-open `>=4.0.0`, so we need to be compatible with both `< 7.0` and `>= 7.0`.)

It also fixes a tsconfig setting to make the linter happy.

NOTE: This is NOT a full migration to compatibility with 7.0, as that will involve a more extensive check of the codebase against the 7.0 migration guide, testing of the changes, etc. When that's done, we also need to update both our peer and dev dependencies.

