### PR TITLE
'errorsOnly' option to disable sending for transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ Sentry.init({
       checkoutEveryNms: 15 * 60 * 1000,
       // on by default
       maskAllInputs: false,
+      // don't attach recordings to transactions
+      errorsOnly: true,
     }),
   ],
   // ...
 });
 ```
 
-See the rrweb documentation for advice on configuring these values.
+See the rrweb documentation for advice on configuring these values. `errorsOnly` is a Sentry-specific configuration paremeter that ensures recording will only be attached if an error happened.

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,9 @@ export default class SentryRRWeb {
     try {
       // short circuit if theres no events to replay
       if (!this.events.length) return;
-      if (this.recordOptions['errorsOnly'] && event.type === 'transaction') return;
+      if (this.recordOptions['errorsOnly'] && event.type === 'transaction') {
+        return event;
+      }
       const client = Sentry.getCurrentHub().getClient();
       const endpoint = self.attachmentUrlFromDsn(
         client.getDsn(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ export default class SentryRRWeb {
     try {
       // short circuit if theres no events to replay
       if (!this.events.length) return;
+      if (this.recordOptions['errorsOnly'] && event.type !== 'error') return;
       const client = Sentry.getCurrentHub().getClient();
       const endpoint = self.attachmentUrlFromDsn(
         client.getDsn(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ type RRWebEvent = {
   delay?: number;
 };
 
-type RRWebOptions = Parameters<typeof record>[0];
+type RRWebOptions = Parameters<typeof record>[0] & { errorsOnly?: boolean; };
 
 export default class SentryRRWeb {
   public readonly name: string = SentryRRWeb.id;
@@ -67,7 +67,7 @@ export default class SentryRRWeb {
     try {
       // short circuit if theres no events to replay
       if (!this.events.length) return;
-      if (this.recordOptions['errorsOnly'] && event.type !== 'error') return;
+      if (this.recordOptions['errorsOnly'] && event.type === 'transaction') return;
       const client = Sentry.getCurrentHub().getClient();
       const endpoint = self.attachmentUrlFromDsn(
         client.getDsn(),


### PR DESCRIPTION
According to Billy Vong: "When an error or transaction event is sent, we save the replay.I'm not sure if the transaction behavior is actually intended since IIRC this was made before we had transactions, so the intention was only to capture replays on errors, but doesn't look like it's been updated to reflect that"

Testing:
BEFORE:
[transaction 4](https://sentry.io/organizations/testorg-az/performance/kosty-application-monitoring-react:a16073897fc64fd799e8705e900edcb7/?project=6633518&query=id%3Aa16073897fc64fd799e8705e900edcb7&statsPeriod=24h&transaction=%2F&unselectedSeries=p100%28%29)
[transaction 5](https://sentry.io/organizations/testorg-az/performance/kosty-application-monitoring-react:cfcefa3c5df44312945d3b5877dde522/?project=6633518&query=id%3Acfcefa3c5df44312945d3b5877dde522&statsPeriod=24h&transaction=%2Fproducts&unselectedSeries=p100%28%29)

AFTER:
[transaction 1](https://sentry.io/organizations/testorg-az/performance/kosty-application-monitoring-react:872b50f626c842e1ba48396fc55833ce/?project=6633518&query=id%3A872b50f626c842e1ba48396fc55833ce&statsPeriod=24h&transaction=%2Fproducts&unselectedSeries=p100%28%29)
[transaction 2](https://sentry.io/organizations/testorg-az/performance/kosty-application-monitoring-react:b559b4e6ac4841f6880d8f8dc628fa96/?project=6633518&query=id%3Ab559b4e6ac4841f6880d8f8dc628fa96&statsPeriod=24h&transaction=%2Fcart&unselectedSeries=p100%28%29)
[transaction 3](https://sentry.io/organizations/testorg-az/performance/kosty-application-monitoring-react:8adcf5c709694e78a5ae04febae46a90/?project=6633518&query=id%3A8adcf5c709694e78a5ae04febae46a90&statsPeriod=24h&transaction=%2Fcheckout&unselectedSeries=p100%28%29)
[error 1](https://sentry.io/organizations/testorg-az/issues/3632568527/events/d122d41548ce46a4b769681d46aee63f/?project=-1&statsPeriod=14d)
Checked no errors in browser console.
Stepped through modified line in debug, does what expected.

```
  new SentryRRWeb({
      maskAllInputs: true,
      maskTextSelector: '*', // everything
      errorsOnly: true,
    }),
```